### PR TITLE
Fix

### DIFF
--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -224,7 +224,7 @@ a:focus {
 }
 
 @-webkit-keyframes pulse {    
-    0 {
+    0% {
         -webkit-transform: scale(1);
         transform: scale(1);
     }
@@ -241,7 +241,7 @@ a:focus {
 }
 
 @-moz-keyframes pulse {    
-    0 {
+    0% {
         -moz-transform: scale(1);
         transform: scale(1);
     }


### PR DESCRIPTION
must declare % on first pulse entry. Some IDE, like WebStorm, expect the % sign and without it will mess with the css.
Thanks