### PR TITLE
Fix for collapsing navbar on a page reload

### DIFF
--- a/js/grayscale.js
+++ b/js/grayscale.js
@@ -5,13 +5,16 @@
  */
 
 // jQuery to collapse the navbar on scroll
-$(window).scroll(function() {
+function collapseNavbar() {
     if ($(".navbar").offset().top > 50) {
         $(".navbar-fixed-top").addClass("top-nav-collapse");
     } else {
         $(".navbar-fixed-top").removeClass("top-nav-collapse");
     }
-});
+}
+
+$(window).scroll(collapseNavbar);
+$(document).ready(collapseNavbar);
 
 // jQuery for page scrolling feature - requires jQuery Easing plugin
 $(function() {


### PR DESCRIPTION
Changed the collapse function to bind to document.ready in addition to window.scroll to allow for a user to refresh the page and have the navbar initialize correctly. 